### PR TITLE
Allow customization of copyright in theme config

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -12,11 +12,15 @@ paginate = 5 #frontpage pagination
 [params]
   slogan = "A fast &amp; secure theme"
   description = "Describe your website" # meta description
-  copyright = "&copy;2018 Göran Svensson"
   author = "Göran Svensson"
   authorLink = "https://appernetic.io/"
   bio = [
     "Göran is an avid blogger and the founder of <a href='https://appernetic.io/'>Appernetic.io</a>. This is the author bio shown after posts."
+  ]
+  copyright = [
+    "&copy; 2018 Göran Svensson",
+    "Nederburg Hugo Theme by [Appernetic](https://appernetic.io).",
+    "A port of Tracks by Compete Themes."
   ]
 
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -98,7 +98,15 @@
         </li>
         {{end}}
 				</ul>	<div class="design-credit">
+		{{ range .Site.Params.copyright }}
+		<p>{{ . | markdownify }}</p>
+		{{ else }}
 		<p>
-			Nederburg Hugo Theme by <a target="_blank" href="https://appernetic.io">Appernetic</a>.</p><p>A port of Tracks by Compete Themes.</p>
+			Nederburg Hugo Theme by <a target="_blank" href="https://appernetic.io">Appernetic</a>.
+		</p>
+		<p>
+			A port of Tracks by Compete Themes.
+		</p>
+		{{ end }}
 	</div>
 </footer>


### PR DESCRIPTION
This fixes #6 It provides an array of copyright string written in markdown syntax. The footer iterates over the array, and displays a paragraph for each string in it. If none provided, then the footer displays a default copyright notice.

In the exampleSite configuration, there was already a copyright param, but it was not used anywhere in the templates so I reused it.