### PR TITLE
Use hugo built-in menu functionality

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -39,17 +39,20 @@ paginate = 5 #frontpage pagination
   email = "goran@molnsys.com"
 
   # Nav links in the side bar
-  [[params.navlinks]]
+  [[menu.main]]
   name = "Home"
-  url = ""
+  url = "/"
+  weight = 1
 
-  [[params.navlinks]]
+  [[menu.main]]
   name = "About"
   url = "about/"
+  weight = 2
 
-  [[params.navlinks]]
+  [[menu.main]]
   name = "Get in touch"
   url = "contact/"
+  weight = 3
 
   [params.social]
   facebook      = "full profile url in facebook"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,21 +16,13 @@
 
     <div class="menu">
       <ul id="menu-primary-items" class="menu-primary-items">
-        <li id="menu-item" class="menu-item menu-item-type-custom menu-item-object-custom current-menu-item current_page_item menu-item-home menu-item">
-          <a href="/">Home</a>
+        {{ $page := . }}
+        {{ range .Site.Menus.main }}
+        <li id="menu-item" class='menu-item {{ if eq ("/") (.URL) }}menu-item-type-custom menu-item-object-custom{{ else }}menu-item-type-post_type menu-item-object-page{{ end }} {{ if $page.IsMenuCurrent "main" . }}current-menu-item current_page_item{{ end }}'>
+          <a href="{{ .URL | absURL }}">{{ .Name }}</a>
         </li>
-
-        {{ range $name, $taxonomy := .Site.Params.Navlinks }}
-        {{ if ne $taxonomy.name "Home" }}
-        <li id="menu-item" class="menu-item menu-item-type-post_type menu-item-object-page menu-item">
-          <a href="/{{ $taxonomy.url | urlize }}">{{ $taxonomy.name }}</a>
-        </li>
-        {{ end }}
         {{ end }}
       </ul>
-
-
-
     </div>
 
   </div>


### PR DESCRIPTION
This pull request, uses hugo built-int menu functionality. It also cleans up some code in the menu handling.

The original template had a harcoded home menu, then skipped any menu entry called Home.

It nows iterate for every menu, and calculates which entry is the current in order to add the proper css classes and then checks whether the menu entry points to "/" in order to add the proper css classes.