### PR TITLE
disqus integration: fixing padding when width major than 1400px

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2638,7 +2638,7 @@ li.pingback:first-child {
 }
 @media all and (min-width: 1400px) {
   #disqus_thread {
-    padding: 1.5em 285px 3em;
+    padding: 1.5em 20px 3em;
   }
 }
 /* bbpress Styles */


### PR DESCRIPTION
fixing padding when min-width major than 1400px (disqus thread was reduced to a slice)
![image](https://user-images.githubusercontent.com/856429/45885689-5820a780-bdb7-11e8-8db4-87be3a0f641b.png)
