### PR TITLE
Fixed issue with category links when category term is two words

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -35,7 +35,7 @@
           <span class="category">
             <span> / </span>
 
-            <a href="/categories{{ . | relURL }}">{{ . }}</a>
+            <a href="/categories/{{ . | urlize }}">{{ . }}</a>
           </span>
           {{ end }}
 

--- a/layouts/partials/category.html
+++ b/layouts/partials/category.html
@@ -59,7 +59,7 @@
 						 {{ range .Params.categories }}
 							<span> / </span>
 						<span class="category">
-							<a href="/categories{{ . | relURL }}">{{ . }}</a>
+							<a href="/categories/{{ . | urlize }}">{{ . }}</a>
 						</span>
 						{{ end }}
 					</div>

--- a/layouts/partials/portfolio.html
+++ b/layouts/partials/portfolio.html
@@ -48,7 +48,7 @@
 						{{ range .Params.categories }}
 						<span> / </span>
 						<span class="category">
-							<a href="/categories{{ . | relURL }}">{{ . }}</a>
+							<a href="/categories/{{ . | urlize }}">{{ . }}</a>
 						</span>
 						{{ end }}
 					</div>

--- a/layouts/partials/tag.html
+++ b/layouts/partials/tag.html
@@ -48,7 +48,7 @@
 						 {{ range .Params.categories }}
 							<span> / </span>
 						<span class="category">
-							<a href="/categories{{ . | relURL }}">{{ . }}</a>
+							<a href="/categories/{{ . | urlize }}">{{ . }}</a>
 						</span>
 						{{ end }}
 					</div>


### PR DESCRIPTION
This PR addresses the Issue #42 I raised the other day.
#42 