### PR TITLE
Google Analytics privacy settings

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -9,6 +9,16 @@ googleAnalytics = ""
 preserveTaxonomyNames = true
 paginate = 5 #frontpage pagination
 
+[privacy]
+  # Google Analytics privacy settings - https://gohugo.io/about/hugo-and-gdpr/index.html#googleanalytics
+  [privacy.googleAnalytics]
+    # set to true to disable service 
+    disable = false
+    # set to true to meet General Data Protection Regulation (GDPR)
+    anonymizeIP = false
+    respectDoNotTrack = false
+    useSessionStorage = false
+
 [params]
   # Unmark to use post folder for images. Default is static folder.
   #usepostimgfolder = true


### PR DESCRIPTION
Google Analytics privacy settings in exampleSite config.toml, so the user can activate if needed to meet General Data Protection Regulation (GDPR) - https://eugdpr.org/ 