### PR TITLE
Remediate HTMLProofer findings

### DIFF
--- a/layouts/contact/list.html
+++ b/layouts/contact/list.html
@@ -3,8 +3,6 @@
 <body class="page-template-default page ct-body singular singular-page not-front standard">
   {{ end }}
   {{ define "main" }}
-  <div id="main" class="main" role="main">
-
 
     <div id="loop-container" class="loop-container">
       <div class="entry">
@@ -49,6 +47,5 @@
           </div>
         </div>
       </div>	</div>
-
-    </div>
+ 
     {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,7 +13,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="all,follow">
 <meta name="googlebot" content="index,follow,snippet,archive">
-<link rel="stylesheet" id="ct-tracks-google-fonts-css" href="//fonts.googleapis.com/css?family=Raleway%3A400%2C700&amp;subset=latin%2Clatin-ext&amp;ver=4.7.2" type="text/css" media="all">
+<link rel="stylesheet" id="ct-tracks-google-fonts-css" href="https://fonts.googleapis.com/css?family=Raleway%3A400%2C700&amp;subset=latin%2Clatin-ext&amp;ver=4.7.2" type="text/css" media="all">
 <!-- Upgraded to Font Awesome 5.3 no need for local files using all.css so all icons are available -->
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
 <!-- Theme stylesheet, if possible do not edit this stylesheet -->

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,12 +18,12 @@
       <ul id="menu-primary-items" class="menu-primary-items">
         {{ $page := . }}
         {{ range .Site.Menus.main }}
-        <li id="menu-item" class='menu-item {{ if eq ("/") (.URL) }}menu-item-type-custom menu-item-object-custom{{ else }}menu-item-type-post_type menu-item-object-page{{ end }} {{ if $page.IsMenuCurrent "main" . }}current-menu-item current_page_item{{ end }}'>
+        <li class='menu-item {{ if eq ("/") (.URL) }}menu-item-type-custom menu-item-object-custom{{ else }}menu-item-type-post_type menu-item-object-page{{ end }} {{ if $page.IsMenuCurrent "main" . }}current-menu-item current_page_item{{ end }}'>
           <a href="{{ .URL | absURL }}">{{ .Name }}</a>
           {{ if .HasChildren }}
           <ul class="sub-menu">
             {{ range .Children }}
-            <li id="menu-item" class='menu-item {{ if eq ("/") (.URL) }}menu-item-type-custom menu-item-object-custom{{ else }}menu-item-type-post_type menu-item-object-page{{ end }} {{ if $page.IsMenuCurrent "main" . }}current-menu-item current_page_item{{ end }}'>
+            <li class='menu-item {{ if eq ("/") (.URL) }}menu-item-type-custom menu-item-object-custom{{ else }}menu-item-type-post_type menu-item-object-page{{ end }} {{ if $page.IsMenuCurrent "main" . }}current-menu-item current_page_item{{ end }}'>
               <a href="{{ .URL | absURL }}">{{ .Name }}</a>
             </li>
             {{ end }}

--- a/layouts/partials/topnavigation.html
+++ b/layouts/partials/topnavigation.html
@@ -7,7 +7,7 @@
 
       <ul id="menu-secondary-items" class="menu-secondary-items">
         {{ range $name, $taxonomy := .Site.Taxonomies.categories }}
-        <li id="menu-item" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item">
+        <li class="menu-item menu-item-type-taxonomy menu-item-object-category">
           <a href="{{ "/categories/" | relLangURL }}{{ $name | urlize }}">{{ $name }}</a>
         </li>
         {{ end }}


### PR DESCRIPTION
Hi,

thanks a lot for creating the theme! I am in the progress of migrating my Jekyll site to Hugo. When I validated the Hugo generated HTML with the [HTMLProofer](https://github.com/gjtorikian/html-proofer) it found a lot of errors.

Those where for example:
```
  *  90:105: ERROR: ID menu-item already defined (line 90)
  *  94:105: ERROR: ID menu-item already defined (line 94)
  *  98:105: ERROR: ID menu-item already defined (line 98)
  *  http://fonts.googleapis.com/css?family=Raleway%3A400%2C700&subset=latin%2Clatin-ext&ver=4.7.2 is not an HTTPS link (line 44)
     <link rel="stylesheet" id="ct-tracks-google-fonts-css" href="//fonts.googleapis.com/css?family=Raleway%3A400%2C700&amp;subset=latin%2Clatin-ext&amp;ver=4.7.2" type="text/css" media="all">
```

I remediated the findings in my commits with no changes to the appearance of the rendered HTML pages.

Best regards
Lars
