### PR TITLE
Removed .RSSLink references.

### DIFF
--- a/layouts/partials/category.html
+++ b/layouts/partials/category.html
@@ -2,10 +2,12 @@
 	<h1>
 		Category: {{ .Title }}
 		{{ if .Site.Params.social.rss }}
-		<a href="{{ .RSSLink }}" data-animate-hover="pulse" class="in-page-rss" target="_blank">
+		{{ with .OutputFormats.Get "RSS" }}
+		<a href="{{ .RelPermalink }}" data-animate-hover="pulse" class="in-page-rss" target="_blank">
             <i class="fas fa-rss" title="rss"></i>
             <span class="screen-reader-text">rss</span>
 		</a>
+		{{ end }}
 		{{ end }}
 	</h1>
 </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -22,8 +22,10 @@
 <link href="{{ "css/custom.css" | absURL }}?v={{ now.Unix }}" rel="stylesheet" type='text/css' media='all'>
 <link rel="shortcut icon" href="{{ "img/favicon.ico" | absURL }}" type="image/x-icon">
 <link rel="icon" href="{{ "img/favicon.ico" | absURL }}" type="image/x-icon">
-{{ if .RSSLink }}
-<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title | default "" }}" />
-<link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title | default "" }}" />
+{{ if .Params.social.rss }}
+{{ with .OutputFormats.Get "RSS" }}
+<link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title | default "" }}" />
+<link href="{{ .RelPermalink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title | default "" }}" />
+{{ end }}
 {{ end }}
 {{ template "_internal/google_analytics_async.html" . }}

--- a/layouts/partials/tag.html
+++ b/layouts/partials/tag.html
@@ -2,10 +2,12 @@
 	<h1>
 		Tag: {{ .Title }}
 		{{ if .Site.Params.social.rss }}
-		<a href="{{ .RSSLink }}" data-animate-hover="pulse" class="in-page-rss" target="_blank">
+		{{ with .OutputFormats.Get "RSS" }}
+		<a href="{{ .RelPermalink }}" data-animate-hover="pulse" class="in-page-rss" target="_blank">
             <i class="fas fa-rss" title="rss"></i>
             <span class="screen-reader-text">rss</span>
 		</a>
+		{{ end }}
 		{{ end }}
 	</h1>
 </div>


### PR DESCRIPTION
This PR should remove the warning about the deprecated `.RSSLink` code. #63 and #65 