### PR TITLE
Add capability to append custom head in head partial.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,5 +25,8 @@
 {{ if .RSSLink }}
 <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title | default "" }}" />
 <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title | default "" }}" />
+
+{{ partial "custom-head" . }}
+
 {{ end }}
 {{ template "_internal/google_analytics_async.html" . }}


### PR DESCRIPTION
Usecase: I wanted just to add a single line to whole head (stylesheet from Google Fonts). I'd rather not copy the whole as it makes update to the template hard - I'd need to backport them to my custom file.

I'm fairly new to hugo ecosystem, so if there is an easier way to achieve this, please let me know. But IIUC there is no way to "inherit" or "extend" an existing layout. 