### PR TITLE
Change the absolute URL to relative URL to enable theme to run in a containerised environment.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,7 +16,7 @@
     {{ if and (isset .Params "image") .Params.image }}
     <div class="post type-post status-publish format-standard has-post-thumbnail hentry category-design tag-design tag-standard-2 tag-tagalicious tag-travel entry full-without-featured odd excerpt-1">
 
-      <div class='featured-image lazy lazy-bg-image' {{ if isset .Site.Params "usepostimgfolder" }} data-background="{{ .Permalink }}{{ .Params.image }}"{{ else }} data-background="{{ .Params.image | absURL }}"{{ end }}>
+      <div class='featured-image lazy lazy-bg-image' {{ if isset .Site.Params "usepostimgfolder" }} data-background="{{ .Permalink }}{{ .Params.image }}"{{ else }} data-background="{{ .Params.image | relURL }}"{{ end }}>
       </div>
       {{ else }}
 
@@ -27,7 +27,7 @@
           <span class="date">{{ .Date.Format "02 January" }}</span>	<span> / </span>
 
           <span class="author">
-            <a href="{{ $writer.link | default .Site.Params.authorlink | absURL }}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a>
+            <a href="{{ $writer.link | default .Site.Params.authorlink | relURL }}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a>
           </span>
 
 
@@ -91,7 +91,7 @@
       <img alt='{{ .Params.writer | default .Site.Params.author }}' src="https://www.gravatar.com/avatar/{{ md5 .Site.Params.email }}?s=100&d=identicon" class='avatar avatar-72 photo' height='72' width='72'>
     {{ end }}
     <span>
-      Written by:<a href="{{ $writer.link | default .Site.Params.authorlink | absURL}}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a> </span>
+      Written by:<a href="{{ $writer.link | default .Site.Params.authorlink | relURL}}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a> </span>
     </div>
     <div class="bio">
       {{ if and (isset .Params "writer") $writer.bio }}

--- a/layouts/partials/category.html
+++ b/layouts/partials/category.html
@@ -33,7 +33,7 @@
 		{{ end }}
 
 		{{ if and (isset .Params "image") .Params.image }}
-			<a class="featured-image-link" href="{{ .Permalink }}"><div class='featured-image lazy lazy-bg-image' {{if isset .Site.Params "usepostimgfolder"}}data-background="{{ .Permalink }}{{ .Params.image }}"{{ else }}data-background="{{ .Params.image | absURL }}"{{ end }}></div></a>
+			<a class="featured-image-link" href="{{ .Permalink }}"><div class='featured-image lazy lazy-bg-image' {{if isset .Site.Params "usepostimgfolder"}}data-background="{{ .Permalink }}{{ .Params.image }}"{{ else }}data-background="{{ .Params.image | relURL }}"{{ end }}></div></a>
 		{{ end }}
 
 				<div class="excerpt-container">
@@ -46,7 +46,7 @@
 								{{ if and (isset .Site.Params "author") .Site.Params.author }}
 								<span> / </span>
 							<span class="author">
-							<a href="{{ $writer.link | default .Site.Params.authorlink | absURL }}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a>
+							<a href="{{ $writer.link | default .Site.Params.authorlink | relURL }}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a>
 							</span>
 								{{ end }}
 							{{ else }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,11 +17,11 @@
 <!-- Upgraded to Font Awesome 5.3 no need for local files using all.css so all icons are available -->
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
 <!-- Theme stylesheet, if possible do not edit this stylesheet -->
-<link href="{{ "css/style.css" | absURL }}?v={{ now.Unix }}" rel="stylesheet" id="theme-stylesheet" type='text/css' media='all'>
+<link href="{{ "css/style.css" | relURL }}?v={{ now.Unix }}" rel="stylesheet" id="theme-stylesheet" type='text/css' media='all'>
 <!-- Custom stylesheet - for your changes -->
-<link href="{{ "css/custom.css" | absURL }}?v={{ now.Unix }}" rel="stylesheet" type='text/css' media='all'>
-<link rel="shortcut icon" href="{{ "img/favicon.ico" | absURL }}" type="image/x-icon">
-<link rel="icon" href="{{ "img/favicon.ico" | absURL }}" type="image/x-icon">
+<link href="{{ "css/custom.css" | relURL }}?v={{ now.Unix }}" rel="stylesheet" type='text/css' media='all'>
+<link rel="shortcut icon" href="{{ "img/favicon.ico" | relURL }}" type="image/x-icon">
+<link rel="icon" href="{{ "img/favicon.ico" | relURL }}" type="image/x-icon">
 {{ if .RSSLink }}
 <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title | default "" }}" />
 <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title | default "" }}" />

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -19,12 +19,12 @@
         {{ $page := . }}
         {{ range .Site.Menus.main }}
         <li class='menu-item {{ if eq ("/") (.URL) }}menu-item-type-custom menu-item-object-custom{{ else }}menu-item-type-post_type menu-item-object-page{{ end }} {{ if $page.IsMenuCurrent "main" . }}current-menu-item current_page_item{{ end }}'>
-          <a href="{{ .URL | absURL }}">{{ .Name }}</a>
+          <a href="{{ .URL | relURL }}">{{ .Name }}</a>
           {{ if .HasChildren }}
           <ul class="sub-menu">
             {{ range .Children }}
             <li class='menu-item {{ if eq ("/") (.URL) }}menu-item-type-custom menu-item-object-custom{{ else }}menu-item-type-post_type menu-item-object-page{{ end }} {{ if $page.IsMenuCurrent "main" . }}current-menu-item current_page_item{{ end }}'>
-              <a href="{{ .URL | absURL }}">{{ .Name }}</a>
+              <a href="{{ .URL | relURL }}">{{ .Name }}</a>
             </li>
             {{ end }}
           </ul>

--- a/layouts/partials/portfolio.html
+++ b/layouts/partials/portfolio.html
@@ -23,7 +23,7 @@
 				{{ end }}
 
 				{{ if and (isset .Params "image") .Params.image }}
-				<a class="featured-image-link" href="{{ .Permalink }}"><div class='featured-image lazy lazy-bg-image' {{if isset .Site.Params "usepostimgfolder"}}data-background="{{ .Permalink }}{{ .Params.image }}"{{ else }}data-background="{{ .Params.image | absURL }}"{{ end }}></div></a>
+				<a class="featured-image-link" href="{{ .Permalink }}"><div class='featured-image lazy lazy-bg-image' {{if isset .Site.Params "usepostimgfolder"}}data-background="{{ .Permalink }}{{ .Params.image }}"{{ else }}data-background="{{ .Params.image | relURL }}"{{ end }}></div></a>
 
 				{{ end }}
 				<div class="excerpt-container">
@@ -34,7 +34,7 @@
 							{{ if and (isset .Site.Params "author") .Site.Params.author }}
 							<span> / </span>
 						<span class="author">
-						<a href="{{ $writer.link | default .Site.Params.authorlink | absURL }}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a>
+						<a href="{{ $writer.link | default .Site.Params.authorlink | relURL }}" title="Posts by {{ .Params.writer | default .Site.Params.author }}" rel="author">{{ .Params.writer | default .Site.Params.author }}</a>
 						</span>
 							{{ end }}
 						{{ else }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,3 +1,3 @@
-<script src="{{ "js/jquery.min.js" | absURL }}"></script>
-<script src="{{ "js/jquerymigrate.js" | absURL }}"></script>
-<script src="{{ "js/production.min.js" | absURL }}?v={{ now.Unix }}"></script>
+<script src="{{ "js/jquery.min.js" | relURL }}"></script>
+<script src="{{ "js/jquerymigrate.js" | relURL }}"></script>
+<script src="{{ "js/production.min.js" | relURL }}?v={{ now.Unix }}"></script>

--- a/layouts/partials/tag.html
+++ b/layouts/partials/tag.html
@@ -26,7 +26,7 @@
 				{{ end }}
 
 				{{ if and (isset .Params "image") .Params.image }}
-				<a class="featured-image-link" href="{{ .Permalink }}"><div class='featured-image lazy lazy-bg-image'   data-background="{{ .Params.image | absURL }}"></div></a>
+				<a class="featured-image-link" href="{{ .Permalink }}"><div class='featured-image lazy lazy-bg-image'   data-background="{{ .Params.image | relURL }}"></div></a>
 
 				{{ end }}
 
@@ -38,7 +38,7 @@
 
 						<span class="author">
 							{{ if and (isset .Site.Params "authorlink") .Site.Params.authorLink }}
-							<a href="{{ .Site.Params.authorLink | default "" | absURL }}" title="Posts by {{ .Site.Params.author | default "" }}" rel="author">{{ .Site.Params.author | default "" }}</a>
+							<a href="{{ .Site.Params.authorLink | default "" | relURL }}" title="Posts by {{ .Site.Params.author | default "" }}" rel="author">{{ .Site.Params.author | default "" }}</a>
 							{{ else }}
 							{{ .Site.Params.author | default "" }}
 							{{ end }}


### PR DESCRIPTION
When running hugo in a containerised environment mapping the links to absolute url doesn't follow the baseURL setting, instead the client browser fails to render certain assets (mainly css & js) as it is pointing to localhost:1313 (for example) changing to relative URL's allows Hugo to render following the baseURL configuration. 